### PR TITLE
Allow uppercase extensions.

### DIFF
--- a/dundunduh/util/__init__.py
+++ b/dundunduh/util/__init__.py
@@ -17,4 +17,4 @@ ALLOWED_FILE_EXTENSIONS = set(['png', 'jpg', 'jpeg', 'gif'])
 
 
 def is_allowed_file(filename):
-    return '.' in filename and filename.rsplit('.', 1)[1] in ALLOWED_FILE_EXTENSIONS
+    return '.' in filename and filename.rsplit('.', 1)[1].lower() in ALLOWED_FILE_EXTENSIONS


### PR DESCRIPTION
Currently, uppercase extensions (such as filename.JPG) are denied with the reason "Invalid File Type."
